### PR TITLE
fix: update React root rendering

### DIFF
--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import 'magic-ui/dist/magic-ui.css';
 import { Button } from 'magic-ui';
 
@@ -22,4 +22,5 @@ function App() {
   );
 }
 
-ReactDOM.render(<App />, document.getElementById('root')); 
+const root = createRoot(document.getElementById('root'));
+root.render(<App />);


### PR DESCRIPTION
## Summary
- use React 18 `createRoot` API for rendering
- restore accidentally modified vendor files

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ba52cf03588329bbb60851d634e0bc