### PR TITLE
feat: add lazy loading and static caching

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,4 +17,5 @@
 - `npm run client`: 启动前端开发服务器。
 
 ## 变更记录
-- *暂无*
+- 为 `index.html` 与 `works.html` 中的图片添加懒加载，并保留首屏关键图片即时加载。
+- 在 `backend/src/index.js` 使用 `express.static` 设置 `Cache-Control` 头。

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,6 +1,15 @@
 const express = require('express');
+const path = require('path');
 const app = express();
 const PORT = process.env.PORT || 3001;
+
+app.use(
+  express.static(path.join(__dirname, '..', '..'), {
+    setHeaders: (res) => {
+      res.set('Cache-Control', 'public, max-age=31536000');
+    },
+  })
+);
 
 app.get('/', (req, res) => {
   res.send('Backend is running');

--- a/index.html
+++ b/index.html
@@ -2419,7 +2419,7 @@
                     <!-- 图片容器 -->
                     <div class="image-placeholder">
                         <!-- 实际的图片将在这里显示，添加data-src属性用于懒加载 -->
-                        <img data-src="project/project1/1.JPG" alt="Interactive Visual Project" style="display: none;" onload="this.style.display='block'; this.parentNode.querySelector('i').style.display='none'; this.parentNode.querySelector('span').style.display='none';">
+                        <img data-src="project/project1/1.JPG" loading="lazy" alt="Interactive Visual Project" style="display: none;" onload="this.style.display='block'; this.parentNode.querySelector('i').style.display='none'; this.parentNode.querySelector('span').style.display='none';">
                         <!-- 仅在图片加载前显示的占位图标 -->
                         <i class="fas fa-image"></i>
                         <span>Interactive Visual Project</span>
@@ -2447,7 +2447,7 @@
                     <!-- 图片容器 -->
                     <div class="image-placeholder">
                         <!-- 实际的图片将在这里显示，添加data-src属性用于懒加载 -->
-                        <img data-src="您的图片路径2" alt="Project 2" style="display: none;" onload="this.style.display='block'; this.parentNode.querySelector('i').style.display='none'; this.parentNode.querySelector('span').style.display='none';">
+                        <img data-src="您的图片路径2" loading="lazy" alt="Project 2" style="display: none;" onload="this.style.display='block'; this.parentNode.querySelector('i').style.display='none'; this.parentNode.querySelector('span').style.display='none';">
                         <!-- 仅在图片加载前显示的占位图标 -->
                         <i class="fas fa-image"></i>
                         <span>Image 2</span>
@@ -2475,7 +2475,7 @@
                     <!-- 图片容器 -->
                     <div class="image-placeholder">
                         <!-- 实际的图片将在这里显示，添加data-src属性用于懒加载 -->
-                        <img data-src="您的图片路径3" alt="Project 3" style="display: none;" onload="this.style.display='block'; this.parentNode.querySelector('i').style.display='none'; this.parentNode.querySelector('span').style.display='none';">
+                        <img data-src="您的图片路径3" loading="lazy" alt="Project 3" style="display: none;" onload="this.style.display='block'; this.parentNode.querySelector('i').style.display='none'; this.parentNode.querySelector('span').style.display='none';">
                         <!-- 仅在图片加载前显示的占位图标 -->
                         <i class="fas fa-image"></i>
                         <span>Image 3</span>
@@ -2503,7 +2503,7 @@
                     <!-- 图片容器 -->
                     <div class="image-placeholder">
                         <!-- 实际的图片将在这里显示，添加data-src属性用于懒加载 -->
-                        <img data-src="您的图片路径4" alt="Project 4" style="display: none;" onload="this.style.display='block'; this.parentNode.querySelector('i').style.display='none'; this.parentNode.querySelector('span').style.display='none';">
+                        <img data-src="您的图片路径4" loading="lazy" alt="Project 4" style="display: none;" onload="this.style.display='block'; this.parentNode.querySelector('i').style.display='none'; this.parentNode.querySelector('span').style.display='none';">
                         <!-- 仅在图片加载前显示的占位图标 -->
                         <i class="fas fa-image"></i>
                         <span>Image 4</span>
@@ -2531,28 +2531,28 @@
                 <div class="slider" id="slider">
                     <div class="slide">
                         <div class="slide-content">
-                            <img src="https://source.unsplash.com/random/600x400/?website,design" alt="Project 1">
+                              <img src="https://source.unsplash.com/random/600x400/?website,design" loading="lazy" alt="Project 1">
                             <h3>Modern Web Design</h3>
                             <p>A sleek and responsive website design for a tech startup, featuring intuitive navigation and stunning visuals.</p>
                         </div>
                     </div>
                     <div class="slide">
                         <div class="slide-content">
-                            <img src="https://source.unsplash.com/random/600x400/?app,mobile" alt="Project 2">
+                              <img src="https://source.unsplash.com/random/600x400/?app,mobile" loading="lazy" alt="Project 2">
                             <h3>Mobile App Interface</h3>
                             <p>An elegant mobile application with seamless user experience and beautiful UI components.</p>
                         </div>
                     </div>
                     <div class="slide">
                         <div class="slide-content">
-                            <img src="https://source.unsplash.com/random/600x400/?branding,logo" alt="Project 3">
+                              <img src="https://source.unsplash.com/random/600x400/?branding,logo" loading="lazy" alt="Project 3">
                             <h3>Brand Identity</h3>
                             <p>Complete brand identity package including logo design, color palette, and marketing materials.</p>
                         </div>
                     </div>
                     <div class="slide">
                         <div class="slide-content">
-                            <img src="https://source.unsplash.com/random/600x400/?ecommerce,shop" alt="Project 4">
+                              <img src="https://source.unsplash.com/random/600x400/?ecommerce,shop" loading="lazy" alt="Project 4">
                             <h3>E-commerce Platform</h3>
                             <p>A fully functional online store with secure payment processing and inventory management.</p>
                         </div>

--- a/works.html
+++ b/works.html
@@ -1308,7 +1308,7 @@
                             <!-- 作品项目1 -->
                             <div class="work-item" data-id="interactive-1">
                                 <div class="work-image">
-                                    <img src="project/Physical Computing&Prototyping/project1/1.JPG" alt="Physical Computing Project">
+                                    <img src="project/Physical Computing&Prototyping/project1/1.JPG" loading="lazy" alt="Physical Computing Project">
                                 </div>
                                 <div class="work-info">
                                     <div>


### PR DESCRIPTION
## Summary
- lazily load non-critical images in index.html and works.html while keeping navbar logos eager
- serve static assets with long-term caching via express.static
- document updates in AGENTS guidelines

## Testing
- `npm test` *(fails: operator 'strictEqual' at backend/test/index.test.js:17)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6353d04c832996850f740d2363fc