### PR TITLE
refactor: centralize navbar creation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,4 +17,4 @@
 - `npm run client`: 启动前端开发服务器。
 
 ## 变更记录
-- *暂无*
+- 新增 `js/navbar.js`，通过 `createNavbar()` 统一注入导航栏至静态页面（index.html、works.html、Contact.html、About ME.html）。

--- a/About ME.html
+++ b/About ME.html
@@ -866,20 +866,7 @@
     </div>
     
     <!-- Navigation Bar -->
-    <div class="navbar-container">
-        <nav class="navbar">
-            <a href="index.html" class="logo">
-                <img src="Z_s_icon.png" alt="Logo">
-            </a>
-            
-            <div class="nav-links">
-                <a href="index.html">Home</a>
-                <a href="About ME.html" class="active">About Me</a>
-                <a href="works.html">Works</a>
-                <a href="Contact.html">Contact</a>
-            </div>
-        </nav>
-    </div>
+    <div class="navbar-container"></div>
     
     <!-- Main Content Section -->
     <section class="page-content">
@@ -1079,6 +1066,7 @@
         </div>
     </section>
     
+    <script src="js/navbar.js"></script>
     <script>
         // Add scroll effect to navbar
         window.addEventListener('scroll', () => {
@@ -1094,25 +1082,9 @@
             }
         });
         
-        // Set active nav link
-        function setActiveNavLink() {
-            const currentPage = window.location.pathname.split('/').pop();
-            const navLinks = document.querySelectorAll('.nav-links a');
-            
-            navLinks.forEach(link => {
-                const href = link.getAttribute('href');
-                link.classList.remove('active');
-                
-                if (href === currentPage) {
-                    link.classList.add('active');
-                } else if (currentPage.includes("About") && href.includes("About")) {
-                    link.classList.add('active');
-                }
-            });
-        }
         
         document.addEventListener('DOMContentLoaded', function() {
-            setActiveNavLink();
+            createNavbar();
             
             // Add animations for the about sections
             const aboutSections = document.querySelectorAll('.about-section');

--- a/Contact.html
+++ b/Contact.html
@@ -802,20 +802,7 @@
     </div>
     
     <!-- Navigation Bar -->
-    <div class="navbar-container">
-        <nav class="navbar">
-            <a href="index.html" class="logo">
-                <img src="Z_s_icon.png" alt="Logo">
-            </a>
-            
-            <div class="nav-links">
-                <a href="index.html">Home</a>
-                <a href="About ME.html">About Me</a>
-                <a href="works.html">Works</a>
-                <a href="Contact.html" class="active">Contact</a>
-            </div>
-        </nav>
-    </div>
+    <div class="navbar-container"></div>
     
     <!-- Page Content Section -->
     <section class="page-content">
@@ -879,6 +866,7 @@
         </div>
     </section>
     
+    <script src="js/navbar.js"></script>
     <script>
         // Add scroll effect to navbar
         window.addEventListener('scroll', () => {
@@ -898,46 +886,7 @@
             }
         });
         
-        // 设置当前页面的导航链接为激活状态
-        function setActiveNavLink() {
-            // 获取当前页面的文件名
-            const currentPage = window.location.pathname.split('/').pop() || 'index.html';
-            console.log("Current page:", currentPage); // 调试输出
-            
-            // 获取所有导航链接
-            const navLinks = document.querySelectorAll('.nav-links a');
-            
-            // 遍历链接，找到对应当前页面的链接添加active类
-            navLinks.forEach(link => {
-                // 获取链接的href属性
-                const href = link.getAttribute('href');
-                console.log("Checking link:", href); // 调试输出
-                
-                // 特殊处理About ME.html页面
-                if (currentPage.includes("About") && currentPage.includes("ME") && 
-                    href.includes("About") && href.includes("ME")) {
-                    link.classList.add('active');
-                }
-                // 特殊处理Contact.html页面
-                else if (currentPage.includes("Contact") && href.includes("Contact")) {
-                    link.classList.add('active');
-                }
-                // 处理其他页面
-                else if ((currentPage === 'index.html' && (href === '#' || href === 'index.html')) ||
-                    (href === currentPage)) {
-                    link.classList.add('active');
-                } else {
-                    link.classList.remove('active');
-                }
-            });
-            
-            // 手动添加active类到Contact链接
-            const contactLink = document.querySelector('.nav-links a[href="Contact.html"]');
-            if (contactLink && currentPage.includes("Contact")) {
-                contactLink.classList.add('active');
-            }
-        }
-        
+        // 设置当前页面的导航链接为激活状态        
         // 页面加载时执行
         document.addEventListener('DOMContentLoaded', function() {
             // 确保没有元素超出视窗宽度
@@ -950,7 +899,7 @@
                 }
             });
             
-            setActiveNavLink();
+            createNavbar();
             
             // 添加页面元素渐入动画效果
             setTimeout(() => {
@@ -996,35 +945,6 @@
                 // 简化显示，只展示时间
                 nyTimeElement.innerHTML = `<div class="time">${nyTime}</div>`;
             }
-        }
-        
-        // Function to scroll to top
-        function scrollToTop() {
-            gsap.to(window, {
-                duration: 1.5,
-                scrollTo: 0,
-                ease: "power2.inOut"
-            });
-        }
-
-        // Add scroll to top functionality for contact link and logo
-        const contactLink = document.querySelector('.nav-links a[href="Contact.html"]');
-        const logo = document.querySelector('.logo');
-        
-        // Contact link should scroll to top of this page
-        if (contactLink) {
-            contactLink.addEventListener('click', (e) => {
-                e.preventDefault(); // Prevent default navigation
-                scrollToTop(); // Scroll smoothly to top
-            });
-        }
-        
-        // Logo should scroll to top of this page
-        if (logo) {
-            logo.addEventListener('click', (e) => {
-                e.preventDefault(); // Prevent default navigation
-                scrollToTop(); // Scroll smoothly to top
-            });
         }
         
         // Custom cursor functionality - 这段代码是被注释的，但为了保持结构一致性，也添加进来

--- a/index.html
+++ b/index.html
@@ -2181,20 +2181,7 @@
     </div>
     
     <!-- Navigation Bar -->
-    <div class="navbar-container">
-        <nav class="navbar">
-            <a href="#" class="logo" style="cursor: pointer !important;">
-                <img src="Z_s_icon.png" alt="Logo">
-            </a>
-            
-            <div class="nav-links">
-                <a href="#" class="active">Home</a>
-                <a href="About ME.html">About Me</a>
-                <a href="works.html">Works</a>
-                <a href="Contact.html">Contact</a>
-            </div>
-        </nav>
-    </div>
+    <div class="navbar-container"></div>
     
     <!-- Hero Section -->
     <section class="hero">
@@ -3881,103 +3868,11 @@
         </div>
     </section>
     
+    
+    <script src="js/navbar.js"></script>
     <script>
-        // 确保logo总是保持pointer光标
-        document.addEventListener('DOMContentLoaded', function() {
-            const logoElement = document.querySelector('.logo');
-            if (logoElement) {
-                logoElement.style.cursor = 'pointer';
-                
-                // 添加鼠标进入和离开事件监听器来强制设置光标
-                logoElement.addEventListener('mouseenter', function() {
-                    this.style.cursor = 'pointer';
-                });
-                
-                logoElement.addEventListener('mousemove', function() {
-                    this.style.cursor = 'pointer';
-                });
-            }
-            
-            // 设置当前页面的导航链接为激活状态
-            function setActiveNavLink() {
-                // 获取当前页面的文件名
-                const currentPage = window.location.pathname.split('/').pop() || 'index.html';
-                console.log("Current page:", currentPage); // 调试输出
-                
-                // 获取所有导航链接
-                const navLinks = document.querySelectorAll('.nav-links a');
-                
-                // 遍历链接，找到对应当前页面的链接添加active类
-                navLinks.forEach(link => {
-                    // 获取链接的href属性
-                    const href = link.getAttribute('href');
-                    console.log("Checking link:", href); // 调试输出
-                    
-                    // 特殊处理About ME.html页面
-                    if (currentPage.includes("About") && currentPage.includes("ME") && 
-                        href.includes("About") && href.includes("ME")) {
-                        link.classList.add('active');
-                    }
-                    // 特殊处理Contact.html页面
-                    else if (currentPage.includes("Contact") && href.includes("Contact")) {
-                        link.classList.add('active');
-                    }
-                    // 特殊处理works.html页面
-                    else if (currentPage.includes("works") && href.includes("works")) {
-                        link.classList.add('active');
-                    }
-                    // 处理主页
-                    else if ((currentPage === 'index.html' || currentPage === '' || currentPage === '/') && 
-                            (href === '#' || href === 'index.html')) {
-                        link.classList.add('active');
-                    }
-                    // 处理其他页面
-                    else if (href === currentPage) {
-                        link.classList.add('active');
-                    } else {
-                        link.classList.remove('active');
-                    }
-                });
-                
-                // 确保主页链接在index页面时激活
-                if (currentPage === 'index.html' || currentPage === '' || currentPage === '/') {
-                    const homeLink = document.querySelector('.nav-links a[href="#"]');
-                    if (homeLink) homeLink.classList.add('active');
-                }
-            }
-            
-            // 页面加载时执行
-            document.addEventListener('DOMContentLoaded', function() {
-                setActiveNavLink();
-                
-                // 添加Home链接的滚动到顶部功能
-                const homeLink = document.querySelector('.nav-links a[href="#"]');
-                if (homeLink) {
-                    homeLink.addEventListener('click', function(e) {
-                        e.preventDefault();
-                        // 使用GSAP平滑滚动到顶部
-                        gsap.to(window, {
-                            duration: 1.5,
-                            scrollTo: 0,
-                            ease: "power2.inOut"
-                        });
-                    });
-                }
-                
-                // 添加Logo的滚动到顶部功能
-                const logoElement = document.querySelector('.logo');
-                if (logoElement) {
-                    logoElement.addEventListener('click', function(e) {
-                        e.preventDefault();
-                        // 使用GSAP平滑滚动到顶部
-                        gsap.to(window, {
-                            duration: 1.5,
-                            scrollTo: 0,
-                            ease: "power2.inOut"
-                        });
-                    });
-                }
-            });
+        document.addEventListener('DOMContentLoaded', () => {
+            createNavbar();
         });
 
         // Responsive animation handler - Debounced resize for Z's World
@@ -3986,23 +3881,20 @@
             clearTimeout(resizeTimeout);
             resizeTimeout = setTimeout(() => {
                 requestAnimationFrame(() => {
-                    // Recalculate animations for main world title
                     const mainWorldTitle = document.querySelector('.world-title');
                     if (mainWorldTitle) {
                         const mainChars = mainWorldTitle.querySelectorAll('.char');
                         gsap.killTweensOf(mainChars);
                         startDefaultWaveEffect(mainChars, mainWorldTitle);
                     }
-                    
-                    // Recalculate animations for name-container world title
+
                     const nameWorldTitle = document.querySelector('.name-container .world');
                     if (nameWorldTitle) {
                         const nameChars = nameWorldTitle.querySelectorAll('.char');
                         gsap.killTweensOf(nameChars);
                         startBreathingAnimation(nameChars, nameWorldTitle);
                     }
-                    
-                    // Recalculate animations for cover world title if visible
+
                     const coverWorldTitle = document.querySelector('.cover-name-container .world');
                     if (coverWorldTitle && coverWorldTitle.offsetParent !== null) {
                         const coverChars = coverWorldTitle.querySelectorAll('.char');
@@ -4013,8 +3905,8 @@
             }, 100);
         };
 
-        // Add resize listener for responsive animations
         window.addEventListener('resize', handleWorldResize);
     </script>
+
 </body>
 </html> 

--- a/js/navbar.js
+++ b/js/navbar.js
@@ -1,0 +1,89 @@
+function createNavbar() {
+    const navbarContainer = document.querySelector('.navbar-container');
+    if (!navbarContainer) return;
+
+    const currentPage = window.location.pathname.split('/').pop() || 'index.html';
+    const isHomePage = currentPage === '' || currentPage === '/' || currentPage === 'index.html';
+
+    const nav = document.createElement('nav');
+    nav.className = 'navbar';
+    nav.innerHTML = `
+        <a href="${isHomePage ? '#' : 'index.html'}" class="logo">
+            <img src="Z_s_icon.png" alt="Logo">
+        </a>
+        <div class="nav-links">
+            <a href="${isHomePage ? '#' : 'index.html'}">Home</a>
+            <a href="About ME.html">About Me</a>
+            <a href="works.html">Works</a>
+            <a href="Contact.html">Contact</a>
+        </div>
+    `;
+    navbarContainer.appendChild(nav);
+
+    const logoElement = nav.querySelector('.logo');
+    if (logoElement) {
+        logoElement.style.cursor = 'pointer';
+        logoElement.addEventListener('mouseenter', () => {
+            logoElement.style.cursor = 'pointer';
+        });
+        logoElement.addEventListener('mousemove', () => {
+            logoElement.style.cursor = 'pointer';
+        });
+    }
+
+    function setActiveNavLink() {
+        const navLinks = nav.querySelectorAll('.nav-links a');
+        navLinks.forEach(link => {
+            const href = link.getAttribute('href');
+            link.classList.remove('active');
+            if (currentPage.includes('About') && currentPage.includes('ME') && href.includes('About') && href.includes('ME')) {
+                link.classList.add('active');
+            } else if (currentPage.includes('Contact') && href.includes('Contact')) {
+                link.classList.add('active');
+            } else if (currentPage.includes('works') && href.includes('works')) {
+                link.classList.add('active');
+            } else if (isHomePage && (href === '#' || href === 'index.html')) {
+                link.classList.add('active');
+            } else if (href === currentPage) {
+                link.classList.add('active');
+            }
+        });
+        if (isHomePage) {
+            const homeLink = nav.querySelector('.nav-links a[href="#"]');
+            if (homeLink) homeLink.classList.add('active');
+        }
+    }
+    setActiveNavLink();
+
+    function scrollToTop() {
+        if (typeof gsap !== 'undefined' && gsap.to) {
+            gsap.to(window, {
+                duration: 1.5,
+                scrollTo: 0,
+                ease: 'power2.inOut'
+            });
+        } else {
+            window.scrollTo({ top: 0, behavior: 'smooth' });
+        }
+    }
+
+    const navLinks = nav.querySelectorAll('.nav-links a');
+    navLinks.forEach(link => {
+        const href = link.getAttribute('href');
+        if (href === '#' || href === currentPage) {
+            link.addEventListener('click', e => {
+                e.preventDefault();
+                scrollToTop();
+            });
+        }
+    });
+
+    if (logoElement && (isHomePage || currentPage.includes('Contact'))) {
+        logoElement.addEventListener('click', e => {
+            e.preventDefault();
+            scrollToTop();
+        });
+    }
+}
+
+window.createNavbar = createNavbar;

--- a/works.html
+++ b/works.html
@@ -1268,20 +1268,7 @@
     </div>
     
     <!-- Navigation Bar -->
-    <div class="navbar-container">
-        <nav class="navbar">
-            <a href="index.html" class="logo">
-                <img src="Z_s_icon.png" alt="Logo">
-            </a>
-            
-            <div class="nav-links">
-                <a href="index.html">Home</a>
-                <a href="About ME.html">About Me</a>
-                <a href="works.html" class="active">Works</a>
-                <a href="Contact.html">Contact</a>
-            </div>
-        </nav>
-    </div>
+    <div class="navbar-container"></div>
     
     <!-- Works Content Section -->
     <section class="works-content">
@@ -1697,6 +1684,7 @@
         </div>
     </section>
     
+    <script src="js/navbar.js"></script>
     <script>
         // Add scroll effect to navbar
         window.addEventListener('scroll', () => {
@@ -1715,32 +1703,9 @@
             }
         });
         
-        // 设置当前页面的导航链接为激活状态
-        function setActiveNavLink() {
-            const currentPage = window.location.pathname.split('/').pop() || 'index.html';
-            const navLinks = document.querySelectorAll('.nav-links a');
-
-            navLinks.forEach(link => {
-                const href = link.getAttribute('href');
-                link.classList.remove('active'); // Remove active from all first
-
-                // Simplified logic for active state
-                if (href === currentPage || (currentPage === 'index.html' && href === '#')) {
-                   link.classList.add('active');
-                } else if (currentPage.includes("About") && href.includes("About")) {
-                    link.classList.add('active');
-                } else if (currentPage.includes("works") && href.includes("works")) {
-                    link.classList.add('active');
-                } else if (currentPage.includes("Contact") && href.includes("Contact")) {
-                     link.classList.add('active');
-                }
-
-            });
-        }
-
         // 修改页面加载时的执行代码
-        document.addEventListener('DOMContentLoaded', function() {
-            setActiveNavLink();
+document.addEventListener('DOMContentLoaded', function() {
+            createNavbar();
 
             // 页面元素的动画效果
             setTimeout(() => {
@@ -1790,26 +1755,6 @@
                 });
             });
 
-            // 回到顶部功能保留
-        function scrollToTop() {
-            gsap.to(window, {
-                duration: 1.5,
-                scrollTo: 0,
-                ease: "power2.inOut"
-            });
-        }
-
-            // 为作品链接添加回到顶部功能
-        const worksLink = document.querySelector('.nav-links a[href="works.html"]');
-        if (worksLink) {
-            worksLink.addEventListener('click', (e) => {
-                 if (window.location.pathname.includes('works.html')) {
-                    e.preventDefault();
-                    scrollToTop();
-                }
-            });
-        }
-        });
 
     </script>
 </body>


### PR DESCRIPTION
## Summary
- add reusable `createNavbar` helper to build navigation and handle active link logic
- load shared navbar on static pages instead of duplicating markup
- document navbar script in AGENTS

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba635e15b08329888a80070bbf147a