### PR TITLE
feat: add lazy image loading and static caching

### DIFF
--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -1,6 +1,20 @@
 const express = require('express');
+const path = require('path');
 const app = express();
 const PORT = process.env.PORT || 3001;
+
+// Serve static assets with caching headers
+app.use(
+  express.static(path.join(__dirname, '..', 'public'), {
+    setHeaders: (res, filePath) => {
+      if (path.extname(filePath) === '.html') {
+        res.setHeader('Cache-Control', 'no-cache');
+      } else {
+        res.setHeader('Cache-Control', 'public, max-age=31536000');
+      }
+    }
+  })
+);
 
 app.get('/', (req, res) => {
   res.send('Backend is running');

--- a/index.html
+++ b/index.html
@@ -2419,7 +2419,7 @@
                     <!-- 图片容器 -->
                     <div class="image-placeholder">
                         <!-- 实际的图片将在这里显示，添加data-src属性用于懒加载 -->
-                        <img data-src="project/project1/1.JPG" alt="Interactive Visual Project" style="display: none;" onload="this.style.display='block'; this.parentNode.querySelector('i').style.display='none'; this.parentNode.querySelector('span').style.display='none';">
+                        <img data-src="project/project1/1.JPG" alt="Interactive Visual Project" loading="lazy" style="display: none;" onload="this.style.display='block'; this.parentNode.querySelector('i').style.display='none'; this.parentNode.querySelector('span').style.display='none';">
                         <!-- 仅在图片加载前显示的占位图标 -->
                         <i class="fas fa-image"></i>
                         <span>Interactive Visual Project</span>
@@ -2447,7 +2447,7 @@
                     <!-- 图片容器 -->
                     <div class="image-placeholder">
                         <!-- 实际的图片将在这里显示，添加data-src属性用于懒加载 -->
-                        <img data-src="您的图片路径2" alt="Project 2" style="display: none;" onload="this.style.display='block'; this.parentNode.querySelector('i').style.display='none'; this.parentNode.querySelector('span').style.display='none';">
+                        <img data-src="您的图片路径2" alt="Project 2" loading="lazy" style="display: none;" onload="this.style.display='block'; this.parentNode.querySelector('i').style.display='none'; this.parentNode.querySelector('span').style.display='none';">
                         <!-- 仅在图片加载前显示的占位图标 -->
                         <i class="fas fa-image"></i>
                         <span>Image 2</span>
@@ -2475,7 +2475,7 @@
                     <!-- 图片容器 -->
                     <div class="image-placeholder">
                         <!-- 实际的图片将在这里显示，添加data-src属性用于懒加载 -->
-                        <img data-src="您的图片路径3" alt="Project 3" style="display: none;" onload="this.style.display='block'; this.parentNode.querySelector('i').style.display='none'; this.parentNode.querySelector('span').style.display='none';">
+                        <img data-src="您的图片路径3" alt="Project 3" loading="lazy" style="display: none;" onload="this.style.display='block'; this.parentNode.querySelector('i').style.display='none'; this.parentNode.querySelector('span').style.display='none';">
                         <!-- 仅在图片加载前显示的占位图标 -->
                         <i class="fas fa-image"></i>
                         <span>Image 3</span>
@@ -2503,7 +2503,7 @@
                     <!-- 图片容器 -->
                     <div class="image-placeholder">
                         <!-- 实际的图片将在这里显示，添加data-src属性用于懒加载 -->
-                        <img data-src="您的图片路径4" alt="Project 4" style="display: none;" onload="this.style.display='block'; this.parentNode.querySelector('i').style.display='none'; this.parentNode.querySelector('span').style.display='none';">
+                        <img data-src="您的图片路径4" alt="Project 4" loading="lazy" style="display: none;" onload="this.style.display='block'; this.parentNode.querySelector('i').style.display='none'; this.parentNode.querySelector('span').style.display='none';">
                         <!-- 仅在图片加载前显示的占位图标 -->
                         <i class="fas fa-image"></i>
                         <span>Image 4</span>
@@ -2531,28 +2531,28 @@
                 <div class="slider" id="slider">
                     <div class="slide">
                         <div class="slide-content">
-                            <img src="https://source.unsplash.com/random/600x400/?website,design" alt="Project 1">
+                            <img src="https://source.unsplash.com/random/600x400/?website,design" alt="Project 1" loading="lazy">
                             <h3>Modern Web Design</h3>
                             <p>A sleek and responsive website design for a tech startup, featuring intuitive navigation and stunning visuals.</p>
                         </div>
                     </div>
                     <div class="slide">
                         <div class="slide-content">
-                            <img src="https://source.unsplash.com/random/600x400/?app,mobile" alt="Project 2">
+                            <img src="https://source.unsplash.com/random/600x400/?app,mobile" alt="Project 2" loading="lazy">
                             <h3>Mobile App Interface</h3>
                             <p>An elegant mobile application with seamless user experience and beautiful UI components.</p>
                         </div>
                     </div>
                     <div class="slide">
                         <div class="slide-content">
-                            <img src="https://source.unsplash.com/random/600x400/?branding,logo" alt="Project 3">
+                            <img src="https://source.unsplash.com/random/600x400/?branding,logo" alt="Project 3" loading="lazy">
                             <h3>Brand Identity</h3>
                             <p>Complete brand identity package including logo design, color palette, and marketing materials.</p>
                         </div>
                     </div>
                     <div class="slide">
                         <div class="slide-content">
-                            <img src="https://source.unsplash.com/random/600x400/?ecommerce,shop" alt="Project 4">
+                            <img src="https://source.unsplash.com/random/600x400/?ecommerce,shop" alt="Project 4" loading="lazy">
                             <h3>E-commerce Platform</h3>
                             <p>A fully functional online store with secure payment processing and inventory management.</p>
                         </div>

--- a/works.html
+++ b/works.html
@@ -1308,7 +1308,7 @@
                             <!-- 作品项目1 -->
                             <div class="work-item" data-id="interactive-1">
                                 <div class="work-image">
-                                    <img src="project/Physical Computing&Prototyping/project1/1.JPG" alt="Physical Computing Project">
+                                    <img src="project/Physical Computing&Prototyping/project1/1.JPG" alt="Physical Computing Project" loading="lazy">
                                 </div>
                                 <div class="work-info">
                                     <div>


### PR DESCRIPTION
## Summary
- add `loading="lazy"` to non-critical images in `index.html` and `works.html`
- serve static assets with `Cache-Control` headers in backend

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba63727ce48329818187e0556a9707