### PR TITLE
Add module docs and cross references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,7 @@
 - `frontend/`: React 前端应用，入口 `frontend/src/index.js`。
 - `project/`: 项目文档与分类说明。
 - 根目录包含若干静态 HTML（如 `index.html`, `works.html`）和资源文件（`styles.css`, `js/`, `Sources/`）。
+- `docs/`: 模块化文档（frontend、backend、deployment 等）。
 
 ## 修改守则
 1. **先读此文件**：任何提交前先阅读 AGENTS.md，确保遵循项目结构和约定。
@@ -17,4 +18,4 @@
 - `npm run client`: 启动前端开发服务器。
 
 ## 变更记录
-- *暂无*
+- 新增 `docs/` 目录，整理前端、后端与部署文档。

--- a/README.md
+++ b/README.md
@@ -1,58 +1,11 @@
 # Design Website
 
-This project is a design website built with React for the frontend and Node.js for the backend. It aims to provide a platform for showcasing design works and projects. 
+This project showcases design works with a React frontend and a Node.js + Express backend.
 
-cd backend
+## Documentation
+- [Frontend Guide](docs/frontend/README.md) – entry point: [`frontend/src/index.js`](frontend/src/index.js)
+- [Backend Guide](docs/backend/README.md) – entry point: [`backend/src/index.js`](backend/src/index.js)
+- [Deployment Guide](docs/deployment/README.md) – run both services locally
 
-npm install express 
-
-node src/index.js 
-
-npm install magic-ui 
-
-import 'magic-ui/dist/magic-ui.css';
-
-import { Button } from 'magic-ui';
-
-import React, { useRef } from 'react';
-import { AnimatedBeam } from './AnimatedBeam';
-
-function MyComponent() {
-  const containerRef = useRef(null);
-  const fromRef = useRef(null);
-  const toRef = useRef(null);
-
-  return (
-    <div ref={containerRef} style={{ position: 'relative', height: '500px' }}>
-      <div ref={fromRef} style={{ position: 'absolute', top: '50px', left: '50px' }}>Start</div>
-      <div ref={toRef} style={{ position: 'absolute', top: '200px', left: '200px' }}>End</div>
-      <AnimatedBeam containerRef={containerRef} fromRef={fromRef} toRef={toRef} />
-    </div>
-  );
-}
-
-npm install motion
-
-npm start
-
-npx create-react-app my-magic-ui-app
-cd my-magic-ui-app
-
-import React from 'react';
-import ReactDOM from 'react-dom';
-import 'magic-ui/dist/magic-ui.css';
-import { Button } from 'magic-ui';
-
-function App() {
-  return (
-    <div style={{ padding: '20px' }}>
-      <h1>Magic UI Demo</h1>
-      <Button>Click Me</Button>
-    </div>
-  );
-}
-
-ReactDOM.render(<App />, document.getElementById('root'));
-
-cd frontend
-npm install react-scripts
+## Magic UI Example
+The frontend demonstrates integration with [Magic UI](https://www.npmjs.com/package/magic-ui). See the snippet in [`frontend/src/index.js`](frontend/src/index.js) and adjust as needed.

--- a/backend/src/index.js
+++ b/backend/src/index.js
@@ -2,11 +2,14 @@ const express = require('express');
 const app = express();
 const PORT = process.env.PORT || 3001;
 
+// Basic health check route.
+// For more details see docs/backend/README.md
 app.get('/', (req, res) => {
   res.send('Backend is running');
 });
 
 if (require.main === module) {
+  // Start the server only when this file is run directly.
   app.listen(PORT, () => {
     console.log(`Server is running on port ${PORT}`);
   });

--- a/docs/backend/README.md
+++ b/docs/backend/README.md
@@ -1,0 +1,14 @@
+# Backend Module
+
+The Node.js + Express server powers API endpoints for the site.
+
+## File Structure
+- [`backend/src/index.js`](../../backend/src/index.js): Server entry point.
+- [`backend/test/`](../../backend/test): Placeholder for backend tests.
+
+## Common Commands
+- `npm install`: install dependencies.
+- `npm run server`: start the server with nodemon.
+- `node backend/src/index.js`: run the server directly.
+
+For frontend details, see [Frontend Docs](../frontend/README.md). For deployment, see [Deployment Guide](../deployment/README.md).

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -1,0 +1,10 @@
+# Deployment Guide
+
+This guide explains how to run the frontend and backend together.
+
+## Steps
+1. Install dependencies: `npm install`.
+2. Start the backend: `npm run server`.
+3. Start the frontend: `npm run client`.
+
+The frontend and backend can also be launched individually; see [Frontend Docs](../frontend/README.md) and [Backend Docs](../backend/README.md) for details.

--- a/docs/frontend/README.md
+++ b/docs/frontend/README.md
@@ -1,0 +1,13 @@
+# Frontend Module
+
+This React application provides the user-facing interface.
+
+## File Structure
+- [`frontend/public/index.html`](../../frontend/public/index.html): HTML template loaded by the app.
+- [`frontend/src/index.js`](../../frontend/src/index.js): Entry point that renders the React components.
+
+## Common Commands
+- `npm install`: install dependencies.
+- `npm run client`: start the development server.
+
+For backend details, see [Backend Docs](../backend/README.md). For deployment, see [Deployment Guide](../deployment/README.md).

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -3,6 +3,8 @@ import { createRoot } from 'react-dom/client';
 import 'magic-ui/dist/magic-ui.css';
 import { Button } from 'magic-ui';
 
+// See docs/frontend/README.md for development details
+
 function App() {
   return (
     <div style={{ 


### PR DESCRIPTION
## Summary
- document frontend, backend, and deployment modules under `docs/`
- link code and README to new module docs
- record docs directory in AGENTS guidelines

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba6373b38483299f752404c83cbb01