### PR TITLE
Add ESLint config and expand backend tests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,11 @@
+{
+  "env": {
+    "commonjs": true,
+    "es2021": true,
+    "node": true
+  },
+  "extends": ["airbnb-base"],
+  "rules": {
+    "no-console": "off"
+  }
+}

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,4 +17,4 @@
 - `npm run client`: 启动前端开发服务器。
 
 ## 变更记录
-- *暂无*
+- 添加 `.eslintrc` 与 `.prettierrc`，并在 `package.json` 中新增 `lint` 与 `test` 脚本。

--- a/backend/test/index.test.js
+++ b/backend/test/index.test.js
@@ -2,18 +2,26 @@ const test = require('node:test');
 const assert = require('node:assert');
 const app = require('../src/index');
 
-// Helper to start server on random port and fetch root
-async function requestRoot() {
+async function request(path = '/', options = {}) {
   const server = app.listen(0);
   const { port } = server.address();
-  const res = await fetch(`http://localhost:${port}/`);
+  const res = await fetch(`http://localhost:${port}${path}`, options);
   server.close();
   return res;
 }
 
 test('GET / returns backend status message', async () => {
-  const res = await requestRoot();
+  const res = await request();
   const text = await res.text();
   assert.strictEqual(text, 'Backend is running');
 });
 
+test('GET /missing returns 404', async () => {
+  const res = await request('/missing');
+  assert.strictEqual(res.status, 404);
+});
+
+test('POST / returns 404', async () => {
+  const res = await request('/', { method: 'POST' });
+  assert.strictEqual(res.status, 404);
+});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "node backend/src/index.js",
     "client": "cd frontend && npm start",
     "server": "cd backend && npm start",
-    "test": "node --test backend/test/index.test.js"
+    "lint": "eslint backend",
+    "test": "node --test"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
## Summary
- set up Airbnb-based ESLint and Prettier configs
- expand backend test coverage with 404 and POST cases
- expose `lint` and simplified `test` scripts in package.json

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba6371fa008329829e490dfbdfcfd7